### PR TITLE
Add CI workflow for tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,19 @@
+name: Tests
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Rust
+        run: rustup update stable
+      - name: Run test suite
+        run: bash ./runtests.sh
+


### PR DESCRIPTION
## Summary
- run `runtests.sh` on pull requests via GitHub Actions

## Testing
- `./runtests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68518b5c69208321a0a16f40d822ba46