### PR TITLE
Fix store_global I64 branch

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -572,7 +572,6 @@ impl CodeGen {
                 "\tmovq\t{}, {}\n",
                 REGISTER_NAMES[register], identifier
             ));
-            panic!("Unexpected type {:?}", ty);
         } else {
             panic!("Unexpected type {:?}", ty);
         }


### PR DESCRIPTION
## Summary
- remove unreachable panic from store_global when handling I64/pointer

## Testing
- `./runtests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685189dc74b0832182345cd032a7faa0