### PR TITLE
Fix logical shift right for unsigned values

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1384,9 +1384,13 @@ impl CodeGen {
         self.assembly
             .text
             .push_str(&format!("\t{}\t {}, {}\n", mov, r, c_register));
+        let shift = match ty {
+            Type::I8 | Type::I16 | Type::I32 | Type::I64 => "sarq",
+            _ => "shrq",
+        };
         self.assembly.text.push_str(&format!(
-            "\tsarq\t {}, {}\n",
-            c_register, REGISTER_NAMES[left]
+            "\t{}\t {}, {}\n",
+            shift, c_register, REGISTER_NAMES[left]
         ));
         self.free_register(right);
         left


### PR DESCRIPTION
## Summary
- correct shift-right code generation when shifting unsigned values

## Testing
- `cargo build`
- `./runtests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68516e76cdc08321ae2b75f9adef5695