### PR TITLE
Fix comment in parser cleanup

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1058,7 +1058,7 @@ impl Parser {
 
         self.current_fn = self.find_symbol(identifier.clone());
         let body = self.compound_statement();
-        // delete local variables and
+        // delete local variables and parameter symbols
         self.symbols.retain(|x| {
             x.borrow().class != StorageClass::Local && x.borrow().class != StorageClass::Param
         });


### PR DESCRIPTION
## Summary
- clarify the cleanup comment near the end of `parse_function`

## Testing
- `./runtests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685189f22be08321a3f804105076b567