### PR TITLE
Fix typo in parser comment

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1342,7 +1342,7 @@ impl Parser {
             }));
 
             if !first_pass {
-                // TODO: Merge it with the bellow symbol, make single creation of a symbol
+                // TODO: Merge it with the below symbol, make single creation of a symbol
                 self.symbols.push(symbol.clone());
                 // self.add_symbol(
                 //     identifier.clone(),


### PR DESCRIPTION
## Summary
- correct a misspelled word in `parser.rs`

## Testing
- `./runtests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685189ed75e48321b679f4919c9d7e77