### PR TITLE
Add Dockerfile for Docker-based tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM rust:latest
+RUN apt-get update -y && apt-get install -y build-essential
+WORKDIR /usr/src/crust
+COPY . .
+RUN chmod +x runtests.sh tests/runtests
+CMD ["./runtests.sh"]

--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ cc -no-pie -z noexecstack -o bin out.s # Use the GNU C compiler to compile and l
 ./runtests.sh
 ```
 
+If you're on macOS or another non-Linux system, you can run the tests in a
+Linux Docker container using the provided `Dockerfile`:
+
+```sh
+./docker_runtests.sh
+```
+
 ## Examples
 
 Some examples of the language

--- a/docker_runtests.sh
+++ b/docker_runtests.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Build and run the Crust tests inside a Docker container.
+# Uses the accompanying Dockerfile to set up the environment.
+set -e
+
+# Build the Docker image (tagged 'crust-tests')
+docker build -t crust-tests .
+
+# Execute the tests in a disposable container
+docker run --rm crust-tests


### PR DESCRIPTION
## Summary
- add Dockerfile that installs build tools and runs `runtests.sh`
- update helper script to build/run this Docker image
- document Docker-based test execution in README

## Testing
- `./runtests.sh`
- `./docker_runtests.sh` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6851edc455c48321a5e82274727be5b3